### PR TITLE
perf: index-only scan for max amount

### DIFF
--- a/docs/schema/shop/bid.sql
+++ b/docs/schema/shop/bid.sql
@@ -7,7 +7,9 @@ create table shop.bid (
   auction_id id not null references shop.auction (id),
   bidder_id id not null references auth.person (id),
   concurrent_amount amount not null default 0,
-  amount amount not null
+  amount amount not null,
+
+  unique (auction_id, amount)
 );
 
 alter table shop.bid enable row level security;


### PR DESCRIPTION
previously:

```sql
# explain select max(amount) from shop.bid where auction_id = '00000000-0000-0000-0000-000000000000';
                                     QUERY PLAN                                      
-------------------------------------------------------------------------------------
 Aggregate  (cost=16.51..16.52 rows=1 width=32)
   ->  Seq Scan on bid  (cost=0.00..16.50 rows=3 width=32)
         Filter: ((auction_id)::uuid = '00000000-0000-0000-0000-000000000000'::uuid)
(3 rows)
```

now:

```sql
# explain select max(amount) from shop.bid where auction_id = '00000000-0000-0000-0000-000000000000';
                                                     QUERY PLAN                                                     
--------------------------------------------------------------------------------------------------------------------
 Result  (cost=5.50..5.51 rows=1 width=32)
   InitPlan 1 (returns $0)
     ->  Limit  (cost=0.15..5.50 rows=1 width=32)
           ->  Index Only Scan Backward using bid_auction_id_amount_key on bid  (cost=0.15..16.21 rows=3 width=32)
                 Index Cond: ((auction_id = '00000000-0000-0000-0000-000000000000'::uuid) AND (amount IS NOT NULL))
(5 rows)
bits=# 
```
